### PR TITLE
Improve navbar with dark mode and responsive sidebar

### DIFF
--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -3,13 +3,28 @@ import './bootstrap';
 document.addEventListener('DOMContentLoaded', () => {
     const sidebarToggle = document.getElementById('sidebarToggle');
     const sidebar = document.getElementById('sidebar');
+    const mainContent = document.getElementById('mainContent');
     const userMenuBtn = document.getElementById('userMenuBtn');
     const userDropdown = document.getElementById('userDropdown');
     const notificationBtn = document.getElementById('notificationBtn');
+    const themeToggle = document.getElementById('themeToggle');
+
+    // Set initial theme
+    if (
+        localStorage.theme === 'dark' ||
+        (!('theme' in localStorage) && window.matchMedia('(prefers-color-scheme: dark)').matches)
+    ) {
+        document.documentElement.classList.add('dark');
+    } else {
+        document.documentElement.classList.remove('dark');
+    }
 
     if (sidebarToggle && sidebar) {
         sidebarToggle.addEventListener('click', () => {
             sidebar.classList.toggle('-translate-x-full');
+            if (mainContent) {
+                mainContent.classList.toggle('lg:ml-64');
+            }
         });
     }
 
@@ -19,9 +34,23 @@ document.addEventListener('DOMContentLoaded', () => {
         });
     }
 
+
     if (notificationBtn) {
         notificationBtn.addEventListener('click', () => {
             alert('No new notifications');
+        });
+    }
+
+    if (themeToggle) {
+        themeToggle.addEventListener('click', () => {
+            const html = document.documentElement;
+            if (html.classList.contains('dark')) {
+                html.classList.remove('dark');
+                localStorage.theme = 'light';
+            } else {
+                html.classList.add('dark');
+                localStorage.theme = 'dark';
+            }
         });
     }
 });

--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -1,18 +1,19 @@
 @extends('layouts.app')
 
 @section('content')
-<div class="flex min-h-screen bg-gray-100">
-    <aside id="sidebar" class="bg-gray-800 text-white w-64 p-4 space-y-2 transition-transform lg:translate-x-0 -translate-x-full lg:relative fixed inset-y-0 left-0 z-20">
+<div class="flex min-h-screen bg-gray-100 dark:bg-gray-900">
+    <aside id="sidebar" class="bg-gray-800 dark:bg-gray-900 text-white w-64 p-4 space-y-2 transition-transform lg:translate-x-0 -translate-x-full lg:relative fixed inset-y-0 left-0 z-20">
         <div class="text-xl font-bold mb-4">Menu</div>
         <nav class="space-y-1">
             <a href="{{ route('dashboard') }}" class="block px-2 py-1 rounded hover:bg-gray-700">Dashboard</a>
             <a href="#" class="block px-2 py-1 rounded hover:bg-gray-700">{{ auth()->user()->name }}</a>
         </nav>
     </aside>
-    <div class="flex-1 flex flex-col lg:ml-64">
-        <nav class="bg-white shadow px-4 py-2 flex items-center justify-between">
-            <button id="sidebarToggle" class="text-gray-600 lg:hidden">☰</button>
+    <div id="mainContent" class="flex-1 flex flex-col lg:ml-64 transition-all">
+        <nav class="bg-white dark:bg-gray-800 dark:text-white shadow px-4 py-2 flex items-center justify-between">
+            <button id="sidebarToggle" class="text-gray-600 dark:text-gray-300">☰</button>
             <div class="flex items-center ml-auto gap-4">
+                <button id="themeToggle" class="text-gray-600 dark:text-gray-300">🌓</button>
                 <button id="notificationBtn" class="text-gray-600">🔔</button>
                 <div class="relative">
                     <button id="userMenuBtn" class="text-gray-600">{{ auth()->user()->name }}</button>

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -6,7 +6,7 @@
     <title>{{ $title ?? config('app.name') }}</title>
     @vite(['resources/css/app.css', 'resources/js/app.js'])
 </head>
-<body class="font-sans antialiased min-h-screen">
+<body class="font-sans antialiased min-h-screen bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100">
     @yield('content')
 </body>
 </html>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,4 +1,5 @@
 export default {
+    darkMode: 'class',
     content: [
         './resources/views/**/*.blade.php',
         './resources/js/**/*.js',


### PR DESCRIPTION
## Summary
- adjust Tailwind config for class-based dark mode
- update layout body classes for dark mode
- add dark-mode aware navbar with theme toggle and responsive sidebar
- toggle sidebar margin via JS and allow switching light/dark theme

## Testing
- `npm install`
- `npm run build`
- `./vendor/bin/phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686660b066a08333b1ff9191221decff